### PR TITLE
Add offset to read lifetime number of resets

### DIFF
--- a/Imports/IC_IdleGameManager64_Import.ahk
+++ b/Imports/IC_IdleGameManager64_Import.ahk
@@ -127,6 +127,7 @@ this.game.gameInstances.Controller.userData.StatHandler := New GameObjectStructu
 this.game.gameInstances.Controller.userData.StatHandler.BlackViperTotalGems := New GameObjectStructure(this.game.gameInstances.Controller.userData.StatHandler,"Int", [0x2c8])
 this.game.gameInstances.Controller.userData.StatHandler.BrivSteelbonesStacks := New GameObjectStructure(this.game.gameInstances.Controller.userData.StatHandler,"Int", [0x330])
 this.game.gameInstances.Controller.userData.StatHandler.BrivSprintStacks := New GameObjectStructure(this.game.gameInstances.Controller.userData.StatHandler,"Int", [0x334])
+this.game.gameInstances.Controller.userData.StatHandler.Resets := New GameObjectStructure(this.game.gameInstances.Controller.userData.StatHandler,"Int", [0xa0])
 this.game.gameInstances.StatHandler := New GameObjectStructure(this.game.gameInstances,"Int", [0x48])
 this.game.gameInstances.StatHandler.NordomAwardedEXP := New GameObjectStructure(this.game.gameInstances.StatHandler,"Int", [0x284])
 this.game.gameInstances.ActiveCampaignData := New GameObjectStructure(this.game.gameInstances,"Int", [0x28])

--- a/MemoryLocations_IdleGameManager.txt
+++ b/MemoryLocations_IdleGameManager.txt
@@ -98,6 +98,7 @@ game.gameInstances.Controller.userData.redRubiesSpent
 game.gameInstances.Controller.userData.StatHandler.BlackViperTotalGems
 game.gameInstances.Controller.userData.StatHandler.BrivSteelbonesStacks
 game.gameInstances.Controller.userData.StatHandler.BrivSprintStacks
+game.gameInstances.Controller.userData.StatHandler.Resets
 game.gameInstances.StatHandler.NordomAwardedEXP
 
 #. ---======================================================================================


### PR DESCRIPTION
Add an offset to read the total number of resets in userdata.
(to use for future addons)