### PR TITLE
Adding levelUpAmount import.

### DIFF
--- a/Settings_BaseClassTypeList/MemoryLocations_IdleGameManager.txt
+++ b/Settings_BaseClassTypeList/MemoryLocations_IdleGameManager.txt
@@ -201,6 +201,7 @@ game.gameInstances.Screen.uiController.bottomBar.formationSaveMenu.formationButt
 game.gameInstances.Screen.uiController.bottomBar.formationSaveMenu.clearButton._x
 game.gameInstances.Screen.uiController.bottomBar.formationSaveMenu.clearButton._y
 game.gameInstances.Screen.uiController.bottomBar.heroPanel.clickDamageBox.maxLevelUpAllowed
+game.gameInstances.Screen.uiController.bottomBar.heroPanel.clickDamageBox.levelUpAmount
 game.gameInstances.Screen.uiController.bottomBar.heroPanel.clickDamageBox.levelUpButtonDisplay.lastCostText
 game.gameInstances.Screen.uiController.notificationManager.notificationDisplay.welcomeBackNotification.Active
 game.gameInstances.Screen.uiController.topBar.dpsMenuBox.menuBox.numberOfUnclaimedQuests


### PR DESCRIPTION
- Used by a fix for Level Up where Ctrl/Shift would get read badly (game's fault). By reading click damage it's far less likely to break.